### PR TITLE
Add certification's approve and wallet field 

### DIFF
--- a/api/translator/models.py
+++ b/api/translator/models.py
@@ -1,6 +1,6 @@
 from django.db import models
 from author.models import Author
-# from django.contrib.postgres.fields import ArrayField
+from django.core.validators import FileExtensionValidator
 
 LEVELS = (
     ("High", "3"),
@@ -21,6 +21,7 @@ class Translator(models.Model):
     username = models.OneToOneField(Author, on_delete=models.CASCADE,
                                     primary_key=True)
     cpf = models.CharField(max_length=14, null=False, blank=False)
+    wallet = models.FloatField(default=0.0)
 
     def __str__(self):
         return str(self.username)
@@ -31,12 +32,15 @@ class Speak(models.Model):
         unique_together = ('language', 'username')
     language = models.ForeignKey(Language, on_delete=models.CASCADE, null=True)
     certification = models.FileField(upload_to="certifications/",
+                                     validators=[FileExtensionValidator(
+                                         allowed_extensions=['pdf'])],
                                      max_length=300, null=True, blank=True)
+    certification_is_valid = models.BooleanField(default=False)
     level = models.CharField(max_length=8, choices=LEVELS)
     username = models.ForeignKey(Translator, on_delete=models.CASCADE)
 
     def save(self, *args, **kwargs):
-        if self.certification is None:
+        if self.certification is None or not self.certification_is_valid:
             self.level = "Low"
         super(Speak, self).save(*args, **kwargs)
 


### PR DESCRIPTION
Add certification's approve and wallet field at translator. Because the level of translator only be able to change if the certification was approve by translate-me staff. And add wallet because during the modelling of db was need wallet attribute on translator,